### PR TITLE
Update Mailgun config

### DIFF
--- a/services.json
+++ b/services.json
@@ -100,10 +100,7 @@
 
     "Mailgun": {
         "host": "smtp.mailgun.org",
-        "port": 587,
-        "tls": {
-            "ciphers": "SSLv3"
-        }
+        "port": 587
     },
 
     "Mailjet": {


### PR DESCRIPTION
Since SSL3 is affected by POODLE attack and Mailgun supports TLSv1.0, I think we need to remove this.
I'm a Mailgun user and checked that is works correctly.
