### PR TITLE
Add GandiMail service

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Service names are case insensitive
   * **'AOL'**
   * **'DynectEmail'**
   * **'FastMail'**
+  * **'GandiMail'**
   * **'Gmail'**
   * **'Godaddy'**
   * **'GodaddyAsia'**

--- a/services.json
+++ b/services.json
@@ -29,6 +29,15 @@
         "secure": true
     },
 
+    "GandiMail": {
+        "aliases": [
+            "Gandi",
+            "Gandi Mail"
+        ],
+        "host": "mail.gandi.net",
+        "port": 587
+    },
+
     "Gmail": {
         "aliases": [
             "Google Mail"


### PR DESCRIPTION
Add [GandiMail](https://www.gandi.net/domain/mail) to the list of well known SMTP services.
As a reference, standard SMTP configuration for Gandi is described on their [wiki](http://wiki.gandi.net/en/mail/standard-settings#smtp_account).

I just tested this configuration myself, from my Ghost blog, and it worked well, please let me know if you need extra details.