### PR TITLE
add DebugMail service

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Service names are case insensitive
 
   * **'1und1'**
   * **'AOL'**
+  * **'DebugMail.io'**
   * **'DynectEmail'**
   * **'FastMail'**
   * **'GandiMail'**

--- a/services.json
+++ b/services.json
@@ -14,6 +14,11 @@
         "port": 587
     },
 
+    "DebugMail": {
+        "host": "debugmail.io",
+        "port": 25
+    },
+
     "DynectEmail": {
         "aliases": ["Dynect"],
         "host": "smtp.dynect.net",


### PR DESCRIPTION
Add [DebugMail](http://debugmail.io/) to the list of well known SMTP services.