### PR TITLE
Add Maildev

### DIFF
--- a/services.json
+++ b/services.json
@@ -112,6 +112,11 @@
         "secure": true
     },
 
+    "Maildev": {
+        "port": 1025,
+        "ignoreTLS": true
+    },
+
     "Mailgun": {
         "host": "smtp.mailgun.org",
         "port": 587


### PR DESCRIPTION
Now this is a bit different service from others, since it's a development tool to be used typically at localhost.

http://djfarrelly.github.io/MailDev/

https://github.com/djfarrelly/MailDev#configure-your-project

Thoughts on adding this here?