### PR TITLE
Update mailgun connection

### DIFF
--- a/services.json
+++ b/services.json
@@ -119,7 +119,8 @@
 
     "Mailgun": {
         "host": "smtp.mailgun.org",
-        "port": 587
+        "port": 465,
+        "secure": true
     },
 
     "Mailjet": {


### PR DESCRIPTION
With port `587` I was getting this error:

```
Nodemailer API error: {"code":"EPROTOCOL","response":"501 5.5.4 Invalid argument","responseCode":501,"command":"HELO"}
```

Also, this adds `secure: true`, because mailgun supports it :)